### PR TITLE
Updates from Hall C version of xscaler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,15 @@ libscaler.a
 
 # Copy this from hana_decode/libdc.a
 libdc_local.a
+# Copy this from hana_decode
+THaDecDict_rdict.pcm
 
 # Copy this from RPC_test
 libscaser.a
 
 # Autogeneraged files in hana_decode
 hana_decode/THaDecDict.*
+hana_decode/*.pcm
 hana_decode/epicsd
 hana_decode/prfact
 hana_decode/tdecex

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ export BUILD_SHARED = 1
 # a fairly stable version and call it libdc_local.a (a local copy).  
 # It's probably good enough.  If not, compile it in ../hana_decode
 # by typing "make libdc.a" and copy it to $(pwd)/libdc_local.a
+# For ROOT 6, the file THaDecDict_rdict.pcm should also be copied
+# from hana_decode.
 
 LIBDC=libdc_local.a
 LIBRPC=libscaser.a

--- a/THaScaler.C
+++ b/THaScaler.C
@@ -547,7 +547,13 @@ Int_t THaScaler::LoadDataRPC(const char* host) {
        if (rpchandle !=0) {
 	 // If we previously opened, assume everything the same
 	 if(!rpcchannels) {
-	   scaserGetInfo(rpchandle,0,&rpcchannels,0,&rpciclock);
+	   if(!scaserGetInfo(rpchandle,0,&rpcchannels,0,&rpciclock)) {
+	     rpcchannels = 0;
+	     rpciclock = 0;
+	     printf("Warning:  RPC scaler server timeout!  Setting values to zero.\n");
+	     ClearAll();
+	     return -1;  // no connection
+	   }
 	   rpcscalers = (int *) malloc(rpcchannels*sizeof(int));
 	   rpcoverflows = (int *) malloc(rpcchannels*sizeof(int));
 	   Int_t slot = (Int_t) (rpciclock/chanPerScaler);

--- a/THaScaler.C
+++ b/THaScaler.C
@@ -560,18 +560,22 @@ Int_t THaScaler::LoadDataRPC(const char* host) {
 	   Int_t chan = rpciclock - chanPerScaler*slot;
 	   if (ldebug) printf("\nRPC scalers: num channels %d  clock chan %d %d %d\n",
 			      rpcchannels,rpciclock, slot, chan);
+	   // If clock not defined, use channel reported by server
+	   if(GetClockSlot() < 0 || GetClockChan() < 0) {
+	     printf("LoadDataRPC:: Warning:  Clock not defined in scaler.map, use server defined slot/chan=%d/%d @ 60Hz\n", slot, chan);
+	     SetClockLoc(slot, chan);
+	     SetClockRate(defaultClkRate);
+	   }
 // Check for consistency versus what was assumed in the scaler.map file "xscaler-clock" line
 // but use the values found here anyway.
 	   if (slot != GetClockSlot()) 
-	     printf("LoadDataRPC:: Warning:  discovered clock slot %d disagrees with scaler map slot %d\n",
+	     printf("LoadDataRPC:: Note:  discovered clock slot %d disagrees with scaler map slot %d\n",
 		    slot,GetClockSlot());
 	   if (chan != GetClockChan()) 
-	     printf("LoadDataRPC:: Warning:  discovered clock chan %d disagrees with scaler map chan %d\n",
+	     printf("LoadDataRPC:: Note:  discovered clock chan %d disagrees with scaler map chan %d\n",
 		    chan,GetClockChan());
-	   SetClockLoc(slot, chan);
 	   if (GetClockRate() != defaultClkRate) 
-	     printf("Warning: Assumed clock rate %f inconsistent with scaler.map\n",GetClockRate());
-	   SetClockRate(defaultClkRate);
+	     printf("Note: Assumed clock rate %f inconsistent with scaler.map\n",GetClockRate());
 	 }
 
        } else {

--- a/THaScaler.C
+++ b/THaScaler.C
@@ -161,7 +161,7 @@ Int_t THaScaler::InitData(std::string bankgroup, const Bdate& date_want) {
 
   struct DataMap {
     const char *bank_name;      // name of bank ("Left", "Right", "dvcs", etc)
-    Int_t bank_header;          // header to find data
+    UInt_t bank_header;          // header to find data
     Int_t bank_cratenum;        // crate number
     Int_t evstr_type;           // part of event stream (1) or evtype 140
     Int_t normslot;             // slot of normalization data (database can
@@ -197,31 +197,31 @@ Int_t THaScaler::InitData(std::string bankgroup, const Bdate& date_want) {
 
    std::string bank_to_find = "unknown";
    if (database) {
-     if ( database->FindNoCase(bankgroup,"Left") != std::string::npos  
+     if ( database->FindNoCase(bankgroup,"Left") != -1  
         || bankgroup == "L" ) {
           bank_to_find = "Left"; 
      }
-     if ( database->FindNoCase(bankgroup,"Right") != std::string::npos  
+     if ( database->FindNoCase(bankgroup,"Right") != -1  
         || bankgroup == "R" ) {
           bank_to_find = "Right"; 
      }
-     if ( database->FindNoCase(bankgroup,"dvcs") != std::string::npos) {
+     if ( database->FindNoCase(bankgroup,"dvcs") != -1) {
           bank_to_find = "dvcs"; 
      }
-     if ( database->FindNoCase(bankgroup,"N20") != std::string::npos) {
+     if ( database->FindNoCase(bankgroup,"N20") != -1) {
           bank_to_find = "N20"; 
      }
-     if ( database->FindNoCase(bankgroup,"evleft") != std::string::npos) {
+     if ( database->FindNoCase(bankgroup,"evleft") != -1) {
           bank_to_find = "evleft"; 
      }
-     if ( database->FindNoCase(bankgroup,"evright") != std::string::npos) {
+     if ( database->FindNoCase(bankgroup,"evright") != -1) {
           bank_to_find = "evright"; 
      }
-     if ( database->FindNoCase(bankgroup,"SHMS") != std::string::npos) {
+     if ( database->FindNoCase(bankgroup,"SHMS") != -1) {
           bank_to_find = "SHMS"; 
           goto done1;
      }
-     if ( database->FindNoCase(bankgroup,"HMS") != std::string::npos) {
+     if ( database->FindNoCase(bankgroup,"HMS") != -1) {
           bank_to_find = "HMS"; 
          goto done1;
      }
@@ -329,7 +329,7 @@ void THaScaler::SetupNormMap() {
   clkchan = GetChan("clock");
   for (Int_t ichan = 0; ichan < SCAL_NUMCHAN; ichan++) {
     std::vector<std::string> chan_name = database->GetShortNames(crate, normslot[0], ichan);
-    for (int i = 0; i < chan_name.size(); i++) {
+    for (UInt_t i = 0; i < chan_name.size(); i++) {
       if (chan_name[i] != "none") {
         normmap.insert(make_pair(chan_name[i], ichan));
       }
@@ -837,8 +837,8 @@ Int_t THaScaler::GetScaler(const char* det, const char* pm, Int_t chan,
   string PMT = pm;
   if ( !did_init | !one_load ) return 0;
   if ( !database ) return 0;
-  if ( database->FindNoCase(PMT,"Left") != std::string::npos ) detector += "L";
-  if ( database->FindNoCase(PMT,"Right") != std::string::npos ) detector += "R";
+  if ( database->FindNoCase(PMT,"Left") != -1 ) detector += "L";
+  if ( database->FindNoCase(PMT,"Right") != -1 ) detector += "R";
   Int_t slot = GetSlot(detector);
   if (slot == -1) return 0;
   return GetScaler(slot,GetChan(detector,0,chan),histor);

--- a/THaScaler.h
+++ b/THaScaler.h
@@ -151,9 +151,9 @@ protected:
    Double_t off_u1,off_u3,off_u10,off_d1,off_d3,off_d10;
    Double_t GetTimeDiff(Int_t helicity);
    void SetupNormMap();
-   CLIENT *rpchandle;
-   int *rpcscalers, *rpcoverflows;
-   int rpcchannels, rpciclock;
+
+  //   int *rpcscalers, *rpcoverflows;
+  //   int rpcchannels, rpciclock;
 
 
    static const Int_t fDebug = 0;

--- a/THaScaler.h
+++ b/THaScaler.h
@@ -132,7 +132,8 @@ protected:
    std::multimap<std::string, Int_t> normmap;
    Int_t *rawdata;
    Bool_t coda_open;
-   Int_t header, crate, evstr_type;
+   UInt_t header;
+   Int_t crate, evstr_type;
    std::string vme_server;
    int vme_port, clkslot, clkchan;
    Bool_t found_crate,first_loop;

--- a/THaScalerDB.C
+++ b/THaScalerDB.C
@@ -173,8 +173,8 @@ std::string THaScalerDB::GetLineType(std::string sline) {
 // Decide if the line is a date, comment, directive, or a map field.
    if (sline.length() == 0) return "COMMENT";
    if (sline.length() == AmtSpace(sline)) return "COMMENT";
-   size_t pos1 = FindNoCase(sline,sdate);
-   size_t pos2 = FindNoCase(sline,scomment);
+   Int_t pos1 = FindNoCase(sline,sdate);
+   Int_t pos2 = FindNoCase(sline,scomment);
    if (pos1 != -1 ) { // date was found
      if (pos2 != -1) {  // comment found
        if (pos2 < pos1) return "COMMENT";
@@ -420,7 +420,7 @@ Int_t THaScalerDB::GetSlotOffset(Int_t crate, Int_t helicity) {
   return atoi(sdir.c_str());
 }
 
-size_t THaScalerDB::FindNoCase(const std::string sdata, const std::string skey) 
+Int_t THaScalerDB::FindNoCase(const std::string sdata, const std::string skey) 
 {
 // Find iterator of word "sdata" where "skey" starts.  Case insensitive.
   std::string sdatalc, skeylc;
@@ -437,7 +437,7 @@ size_t THaScalerDB::FindNoCase(const std::string sdata, const std::string skey)
   return sdatalc.find(skeylc,0);
 }
 
-Int_t THaScalerDB::AmtSpace(const std::string& s) {
+UInt_t THaScalerDB::AmtSpace(const std::string& s) {
   typedef std::string::size_type string_size;
   Int_t nsp = 0;  string_size i = 0;
   while (i++ != s.size()) if(isspace(s[i])) nsp++;

--- a/THaScalerDB.C
+++ b/THaScalerDB.C
@@ -169,32 +169,27 @@ void THaScalerDB::PrintDirectives() {
 };
 
 
-std::string THaScalerDB::GetLineType(std::string sline) {
+std::string THaScalerDB::GetLineType(std::string s) {
 // Decide if the line is a date, comment, directive, or a map field.
+   std::string sline = s;
+   Int_t poscomment = FindNoCase(sline, scomment);
+   if (poscomment >= 0) {	// Strip comments
+     sline.resize(poscomment);
+   }
+   // Line is comment if empty or all space
    if (sline.length() == 0) return "COMMENT";
    if (sline.length() == AmtSpace(sline)) return "COMMENT";
-   Int_t pos1 = FindNoCase(sline,sdate);
-   Int_t pos2 = FindNoCase(sline,scomment);
-   if (pos1 != -1 ) { // date was found
-     if (pos2 != -1) {  // comment found
-       if (pos2 < pos1) return "COMMENT";
-     }
+   if (FindNoCase(sline,sdate)  != -1 ) { // date was found
      return "DATE";
    }
-// Directives line, even if after a comment (#)
-// as long as not too far after (fgnfar)
    std::string result;
-   if (pos2 == -1 || pos2 < fgnfar) {
-    for (UInt_t i=0; i<directnames.size(); i++) {
-     pos1 = FindNoCase(sline, directnames[i]);
+   for (UInt_t i=0; i<directnames.size(); i++) {
+     Int_t pos1 = FindNoCase(sline, directnames[i]);
      if (pos1 != -1) {
-      result.assign(sline.substr(pos1,sline.length()));;
-      return result;
+       result.assign(sline.substr(pos1,sline.length()));;
+       return result;
      }
-    }
    }
-// Not a directive but has a comment near start.
-   if (pos2 != std::string::npos && pos2 < fgnfar) return "COMMENT";
 // otherwise its a map line
    return "MAP";
 }

--- a/THaScalerDB.h
+++ b/THaScalerDB.h
@@ -235,7 +235,7 @@ public:
    virtual ~THaScalerDB();
    bool extract_db(const Bdate& bdate);
    std::string GetLongDesc(Int_t crate, std::string desc, Int_t helicity=0);
-   size_t FindNoCase(const std::string s1, const std::string s2);
+   Int_t FindNoCase(const std::string s1, const std::string s2);
    Int_t GetSlot(Int_t crate, std::string desc, Int_t helicity=0);
    Int_t GetChan(Int_t crate, std::string desc, Int_t helicity=0, Int_t chan=0);
    std::vector<std::string> GetShortNames(Int_t crate, Int_t slot, Int_t chan);
@@ -268,7 +268,7 @@ private:
    Bool_t IsHelicityTied(Int_t crate, Int_t helicity);
    Int_t TiedCrate(Int_t crate, Int_t helicity);
    Int_t GetSlotOffset(Int_t crate, Int_t helicity);
-   Int_t AmtSpace(const std::string& s);
+   UInt_t AmtSpace(const std::string& s);
    std::vector<std::string> vsplit(const std::string& s);
    // Map of (crate/page) to vector of (slot/channel)
    std::map<std::pair<Int_t, Int_t>, std::vector<std::pair<Int_t, Int_t> > > pagemap;

--- a/scaler.map_example
+++ b/scaler.map_example
@@ -14,32 +14,34 @@ DATE 4 1 2017
 
 # Setup for Hall C testing HMS hodoscopes, etc.
 
-xscaler-tabs     HMS 0:X1      1:Y1      2:X2      3:Y2      4:Trig   5:Triggers
-xscaler-layout   HMS 0:8x4     1:8x4     2:8x4     3:8x4     4:8x4    5:8x4
-xscaler-pageslot HMS 0:page0   1:page1   2:page2   3:page3   4:slot6  5:slot5
+xscaler-tabs     HMS 0:1X      1:1Y      2:2X      3:2Y      4:Trigger    5:Trigger    6:Trigger
+xscaler-layout   HMS 0:8x4     1:8x4     2:8x4     3:8x4     4:8x4        5:8x4        6:8x4
+xscaler-pageslot HMS 0:page0   1:page1   2:page2   3:page3   4:slot6      5:slot5      6:slot4
 
-xscaler-pagename HMS 0:'HMS Hodoscope X1'
-xscaler-pagename HMS 1:'HMS Hodoscope Y1'
-xscaler-pagename HMS 2:'HMS Hodoscope X2'
-xscaler-pagename HMS 3:'HMS Hodoscope Y2'
-xscaler-pagename HMS 4:'HMS Trigger,BCM and clock'
-xscaler-pagename HMS 5:'HMS Triggers'
+xscaler-pagename HMS 0:'HMS Hodoscope Plane 1X'
+xscaler-pagename HMS 1:'HMS Hodoscope Plane 1Y'
+xscaler-pagename HMS 2:'HMS Hodoscope Plane 2X'
+xscaler-pagename HMS 3:'HMS Hodoscope Plane 2Y'
+xscaler-pagename HMS 4:'HMS Trigger & Beamline'
+xscaler-pagename HMS 5:'HMS Trigger'
+xscaler-pagename HMS 6:'HMS Trigger'
 
 xscaler-clock HMS slot:7 chan:1 rate:60 
 #####################################################################
 
 # Setup for Hall C testing SHMS hodoscopes, etc.
 
-xscaler-tabs     SHMS 0:X1      1:Y1      2:X2      3:Y2      4:Trig   5:Triggers
-xscaler-layout   SHMS 0:8x4     1:8x4     2:8x4     3:8x4     4:8x4    5:8x4
-xscaler-pageslot SHMS 0:page0   1:page1   2:page2   3:page3   4:slot7  5:slot6
+xscaler-tabs     SHMS 0:1X      1:1Y      2:2X      3:2Y      4:Trigger   5:Trigger   6:Trigger
+xscaler-layout   SHMS 0:8x4     1:8x4     2:8x4     3:8x4     4:8x4       5:8x4       6:8x4
+xscaler-pageslot SHMS 0:page0   1:page1   2:page2   3:page3   4:slot7     5:slot6     6:slot5
 
-xscaler-pagename SHMS 0:'SHMS Hodoscope X1'
-xscaler-pagename SHMS 1:'SHMS Hodoscope Y1'
-xscaler-pagename SHMS 2:'SHMS Hodoscope X2'
-xscaler-pagename SHMS 3:'SHMS Hodoscope Y2'
-xscaler-pagename SHMS 4:'SHMS Trigger,BCM and clock'
-xscaler-pagename SHMS 5:'SHMS Triggers'
+xscaler-pagename SHMS 0:'SHMS Hodoscope Plane 1X'
+xscaler-pagename SHMS 1:'SHMS Hodoscope Plane 1Y'
+xscaler-pagename SHMS 2:'SHMS Hodoscope Plane 2X'
+xscaler-pagename SHMS 3:'SHMS Hodoscope Plane 2Y'
+xscaler-pagename SHMS 4:'SHMS Trigger & Beamline'
+xscaler-pagename SHMS 5:'SHMS Trigger'
+xscaler-pagename SHMS 6:'SHMS Trigger'
 
 xscaler-clock SHMS slot:8 chan:1 rate:60
 #####################################################################
@@ -194,18 +196,58 @@ hhod2y10-    0    4     3    28    1    3   HMS 2Y- paddle 10
 9/31         0    4     3    31    1    3   Empty
 
 # desc      hel crate slot start nchan page long-description
-hTRIG1       0    4     5    10    1    -1  HMS  TRIG1
-hTRIG2       0    4     5    11    1    -1  HMS  TRIG2
-hTRIG3       0    4     5    12    1    -1  HMS  TRIG3
-hTRIG4       0    4     5    13    1    -1  HMS  TRIG4
-hTRIG5       0    4     5    14    1    -1  HMS  TRIG5
-hTRIG6       0    4     5    15    1    -1  HMS  TRIG6
+pPRE40       0    4     4    0     1    -1  SHMS PRE40
+pPRE100      0    4     4    1     1    -1  SHMS PRE100
+pPRE150      0    4     4    2     1    -1  SHMS PRE150
+pPRE200      0    4     4    3     1    -1  SHMS PRE200
+10/4         0    4     4    4     1    -1  Empty
+10/5         0    4     4    5     1    -1  Empty
+10/6         0    4     4    6     1    -1  Empty
+10/7         0    4     4    7     1    -1  Empty
+hPRE40       0    4     4    8     1    -1  HMS PRE40
+hPRE100      0    4     4    9     1    -1  HMS PRE100
+hPRE150      0    4     4    10    1    -1  HMS PRE150
+hPRE200      0    4     4    11    1    -1  HMS PRE200
+10/12        0    4     4    12    1    -1  Empty
+10/13        0    4     4    13    1    -1  Empty
+10/14        0    4     4    14    1    -1  Empty
+10/15        0    4     4    15    1    -1  Empty
+# desc      hel crate slot start nchan page long-description
+hL1ACCP       0    4     4    16     1    -1  HMS L1 Accept
+
+# desc      hel crate slot start nchan page long-description
 pTRIG1       0    4     5    0     1    -1  SHMS TRIG1
 pTRIG2       0    4     5    1     1    -1  SHMS TRIG2
 pTRIG3       0    4     5    2     1    -1  SHMS TRIG3
 pTRIG4       0    4     5    3     1    -1  SHMS TRIG4
 pTRIG5       0    4     5    4     1    -1  SHMS TRIG5
 pTRIG6       0    4     5    5     1    -1  SHMS TRIG6
+12/6         0    4     5    6     1    -1  Empty
+12/7         0    4     5    7     1    -1  Empty
+12/8         0    4     5    8     1    -1  Empty
+12/9         0    4     5    9     1    -1  Empty
+hTRIG1       0    4     5    10    1    -1  HMS TRIG1
+hTRIG2       0    4     5    11    1    -1  HMS TRIG2
+hTRIG3       0    4     5    12    1    -1  HMS TRIG3
+hTRIG4       0    4     5    13    1    -1  HMS TRIG4
+hTRIG5       0    4     5    14    1    -1  HMS TRIG5
+hTRIG6       0    4     5    15    1    -1  HMS TRIG6
+pSTOF        0    4     5    16    1    -1  SHMS STOF
+pEL_LO_LO    0    4     5    17    1    -1  SHMS EL_LO_LO
+pEL_LO       0    4     5    18    1    -1  SHMS EL_LO
+pEL_HI       0    4     5    19    1    -1  SHMS EL_HI
+pEL_REAL     0    4     5    20    1    -1  SHMS EL_REAL
+pEL_CLEAN    0    4     5    21    1    -1  SHMS EL_CLEAN
+12/22        0    4     5    22    1    -1  Empty
+12/23        0    4     5    23    1    -1  Empty
+hSTOF        0    4     5    24    1    -1  HMS STOF
+hEL_LO_LO    0    4     5    25    1    -1  HMS EL_LO_LO
+hEL_LO       0    4     5    26    1    -1  HMS EL_LO
+hEL_HI       0    4     5    27    1    -1  HMS EL_HI
+hEL_REAL     0    4     5    28    1    -1  HMS EL_REAL
+hEL_CLEAN    0    4     5    29    1    -1  HMS EL_CLEAN
+12/30        0    4     5    30    1    -1  Empty
+12/31        0    4     5    31    1    -1  Empty
 
 # desc      hel crate slot start nchan page long-description
 S1X          0    4     6    0     1    -1  HMS S1X
@@ -214,21 +256,30 @@ S2X          0    4     6    2     1    -1  HMS S2X
 S2Y          0    4     6    3     1    -1  HMS S2Y
 S1XS1Y       0    4     6    4     1    -1  HMS S1T
 S2XS2Y       0    4     6    5     1    -1  HMS S2T
-Trig         0    4     6    6     1    -1  HMS T1
+hTREF1       0    4     6    6     1    -1  HMS TREF1
 ASUM         0    4     6    7     1    -1  HMS ASUM
 BSUM         0    4     6    8     1    -1  HMS BSUM
 CSUM         0    4     6    9     1    -1  HMS CSUM
 DSUM         0    4     6    10    1    -1  HMS DSUM
-PSHWRLO      0    4     6    11    1    -1  HMS PSHWRLO
-PSHWRHI      0    4     6    12    1    -1  HMS PSHWRHI
-SHWR         0    4     6    13    1    -1  HMS SHWR
-HOD_EDTM     0    4     6    14    1    -1  HMS HODO EDTM
-CERSUM       0    4     6    15    1    -1  HMS CERSUM
-BCM4A        0    4     6    25    1    -1  bcm4a
-BCM4B        0    4     6    26    1    -1  bcm4b
-BCM1         0    4     6    27    1    -1  bcm1
-BCM2         0    4     6    28    1    -1  bcm2 
-BCM17        0    4     6    29    1    -1  bcm17
+PRLO         0    4     6    11    1    -1  HMS PRLO
+PRHI         0    4     6    12    1    -1  HMS PRHI
+SHLO         0    4     6    13    1    -1  HMS SHLO
+EDTM         0    4     6    14    1    -1  HMS EDTM
+CER          0    4     6    15    1    -1  HMS CER
+21/16        0    4     6    16    1    -1  Empty
+21/17        0    4     6    17    1    -1  Empty
+21/18        0    4     6    18    1    -1  Empty
+21/19        0    4     6    19    1    -1  Empty
+21/20        0    4     6    20    1    -1  Empty
+21/21        0    4     6    21    1    -1  Empty
+21/22        0    4     6    22    1    -1  Empty
+21/23        0    4     6    23    1    -1  Empty
+21/24        0    4     6    24    1    -1  Empty
+BCM4A        0    4     6    25    1    -1  BCM4a
+BCM4B        0    4     6    26    1    -1  BCM4b
+BCM1         0    4     6    27    1    -1  BCM1
+BCM2         0    4     6    28    1    -1  BCM2 
+BCM17        0    4     6    29    1    -1  BCM17
 Unser        0    4     6    30    1    -1  Unser
 1Mhz         0    4     6    31    1    -1  1MHz  
                                         
@@ -426,38 +477,60 @@ phod2y21-    0    5     4    2     1    -1  SHMS 2y- paddle 21
 10/15        0    5     4    15    1    -1  Empty
 
 # desc      hel crate slot start nchan page long-description
+pPRE40       0    5     5    0     1    -1  SHMS PRE40
+pPRE100      0    5     5    1     1    -1  SHMS PRE100
+pPRE150      0    5     5    2     1    -1  SHMS PRE150
+pPRE200      0    5     5    3     1    -1  SHMS PRE200
+11/4         0    5     5    4     1    -1  Empty
+11/5         0    5     5    5     1    -1  Empty
+11/6         0    5     5    6     1    -1  Empty
+11/7         0    5     5    7     1    -1  Empty
+hPRE40       0    5     5    8     1    -1  HMS PRE40
+hPRE100      0    5     5    9     1    -1  HMS PRE100
+hPRE150      0    5     5    10    1    -1  HMS PRE150
+hPRE200      0    5     5    11    1    -1  HMS PRE200
+11/12        0    5     5    12    1    -1  Empty
+11/13        0    5     5    13    1    -1  Empty
+11/14        0    5     5    14    1    -1  Empty
+11/15        0    5     5    15    1    -1  Empty
+
+# desc      hel crate slot start nchan page long-description
+pL1ACCP       0    5     5    16     1    -1  SHMS PRE40
+
+
+# desc      hel crate slot start nchan page long-description
 pTRIG1       0    5     6    0     1    -1  SHMS TRIG1
 pTRIG2       0    5     6    1     1    -1  SHMS TRIG2
 pTRIG3       0    5     6    2     1    -1  SHMS TRIG3
 pTRIG4       0    5     6    3     1    -1  SHMS TRIG4
 pTRIG5       0    5     6    4     1    -1  SHMS TRIG5
 pTRIG6       0    5     6    5     1    -1  SHMS TRIG6
+12/6         0    5     6    6     1    -1  Empty
+12/7         0    5     6    7     1    -1  Empty
+12/8         0    5     6    8     1    -1  Empty
+12/9         0    5     6    9     1    -1  Empty
 hTRIG1       0    5     6    10    1    -1  HMS  TRIG1
 hTRIG2       0    5     6    11    1    -1  HMS  TRIG2
 hTRIG3       0    5     6    12    1    -1  HMS  TRIG3
 hTRIG4       0    5     6    13    1    -1  HMS  TRIG4
 hTRIG5       0    5     6    14    1    -1  HMS  TRIG5
 hTRIG6       0    5     6    15    1    -1  HMS  TRIG6
-12/6         0    5     6    6     1    -1  Empty
-12/7         0    5     6    7     1    -1  Empty
-12/8         0    5     6    8     1    -1  Empty
-12/9         0    5     6    9     1    -1  Empty
-12/16        0    5     6    16    1    -1  Empty
-12/17        0    5     6    17    1    -1  Empty
-12/18        0    5     6    18    1    -1  Empty
-12/19        0    5     6    19    1    -1  Empty
-12/20        0    5     6    20    1    -1  Empty
-12/21        0    5     6    21    1    -1  Empty
+pSTOF        0    5     6    16    1    -1  SHMS STOF
+pEL_LO_LO    0    5     6    17    1    -1  SHMS EL_LO_LO
+pEL_LO       0    5     6    18    1    -1  SHMS EL_LO
+pEL_HI       0    5     6    19    1    -1  SHMS EL_HI
+pEL_REAL     0    5     6    20    1    -1  SHMS EL_REAL
+pEL_CLEAN    0    5     6    21    1    -1  SHMS EL_CLEAN
 12/22        0    5     6    22    1    -1  Empty
 12/23        0    5     6    23    1    -1  Empty
-12/24        0    5     6    24    1    -1  Empty
-12/25        0    5     6    25    1    -1  Empty
-12/26        0    5     6    26    1    -1  Empty
-12/27        0    5     6    27    1    -1  Empty
-12/28        0    5     6    28    1    -1  Empty
-12/29        0    5     6    29    1    -1  Empty
-12/30        0    5     6    30    1    -1  Empty
-12/31        0    5     6    31    1    -1  Empty
+hSTOF        0    5     6    24    1    -1  HMS STOF
+hEL_LO_LO    0    5     6    25    1    -1  HMS EL_LO_LO
+hEL_LO       0    5     6    26    1    -1  HMS EL_LO
+hEL_HI       0    5     6    27    1    -1  HMS EL_HI
+hEL_REAL     0    5     6    28    1    -1  HMS EL_REAL
+hEL_CLEAN    0    5     6    29    1    -1  HMS EL_CLEAN
+12/29        0    5     6    30    1    -1  Empty
+12/30        0    5     6    31    1    -1  Empty
 
 # desc      hel crate slot start nchan page long-description
 S1X          0    5     7    0     1    -1  SHMS S1X
@@ -466,20 +539,13 @@ S2X          0    5     7    2     1    -1  SHMS S2X
 S2Y          0    5     7    3     1    -1  SHMS S2Y
 S1XS1Y       0    5     7    4     1    -1  SHMS S1T
 S2XS2Y       0    5     7    5     1    -1  SHMS S2T
-Trig         0    5     7    6     1    -1  SHMS T1
+pTREF3       0    5     7    6     1    -1  SHMS TREF3
 AERO         0    5     7    7     1    -1  SHMS AERO
-HGC          0    5     7    8     1    -1  SHMS HGC
-NGC          0    5     7    9     1    -1  SHMS NGC
-HOD_EDTM     0    5     7    10    1    -1  SHMS HODO EDTM
-BCM4A        0    5     7    25    1    -1  bcm4a
-BCM4B        0    5     7    26    1    -1  bcm4b
-BCM1         0    5     7    27    1    -1  bcm1
-BCM2         0    5     7    28    1    -1  bcm2
-BCM17        0    5     7    29    1    -1  bcm17
-Unser        0    5     7    30    1    -1  Unser
-1Mhz         0    5     7    31    1    -1  1MHz
-13/11        0    5     7    11    1    -1  Empty
-13/12        0    5     7    12    1    -1  Empty
+HCER         0    5     7    8     1    -1  SHMS HGC
+NCER         0    5     7    9     1    -1  SHMS NGC
+EDTM         0    5     7    10    1    -1  SHMS EDTM
+PRLO         0    5     7    11    1    -1  SHMS PRLO
+PRHI         0    5     7    12    1    -1  SHMS PRHI
 13/13        0    5     7    13    1    -1  Empty
 13/14        0    5     7    14    1    -1  Empty
 13/15        0    5     7    15    1    -1  Empty
@@ -492,6 +558,13 @@ Unser        0    5     7    30    1    -1  Unser
 13/22        0    5     7    22    1    -1  Empty
 13/23        0    5     7    23    1    -1  Empty
 13/24        0    5     7    24    1    -1  Empty
+BCM4A        0    5     7    25    1    -1  BCM4a
+BCM4B        0    5     7    26    1    -1  BCM4b
+BCM1         0    5     7    27    1    -1  BCM1
+BCM2         0    5     7    28    1    -1  BCM2
+BCM17        0    5     7    29    1    -1  BCM17
+Unser        0    5     7    30    1    -1  Unser
+1Mhz         0    5     7    31    1    -1  1MHz
 
 # desc      hel crate slot start nchan page long-description
 clock        0    5     8    1     1    -1  clock


### PR DESCRIPTION
These changes add compatibility with ROOT 6 on RHEL7 machines.

Includes some changes in the Hall C example scaler.map_example.

Fixes some issues specific to RPC scaler servers.

These changes should not break Hall A compatibility.  This is also what I will start with to make an xscaler that talks to the new RPC scaler servers being setup for the SBS era.